### PR TITLE
Repeated variable fix

### DIFF
--- a/drivers/RdbmsDriverTrait.php
+++ b/drivers/RdbmsDriverTrait.php
@@ -7,8 +7,6 @@ use yii\db\Connection;
 
 trait RdbmsDriverTrait
 {
-    protected $dsn;
-
     public function initDsn(Connection $connection)
     {
         $this->dsn['username'] = $connection->username;


### PR DESCRIPTION
PHP Strict Warning 'yii\base\ErrorException' with message 'dizews\dbConsole\Driver and dizews\dbConsole\drivers\RdbmsDriverTrait define the same property ($dsn) in the composition of dizews\dbConsole\drivers\Mysql. This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed'
